### PR TITLE
Add `topic_tools` package dependency

### DIFF
--- a/stretch_gz_sim/package.xml
+++ b/stretch_gz_sim/package.xml
@@ -17,6 +17,7 @@
   <test_depend>ament_lint_common</test_depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Adding the missing dependency `topic_tools` in `package.xml` so that the command
```bash
rosdep install --from-paths src --ignore-src -r -y
```
Installs all the required dependencies.